### PR TITLE
Add MANIFEST.in to include sibc/data

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include sibc/data *


### PR DESCRIPTION
This patch introduces a MANIFEST.in file. This is used in source distributions.
When installing sibc on archlinux using `python setup.py install --user` the data directory is omitted.

Without the data the program crashes immediately.

This can be fixed by specifying the path in the MANIFEST.in file.