### PR TITLE
optimize csidh 2022

### DIFF
--- a/sibc/bsidh/strategy.py
+++ b/sibc/bsidh/strategy.py
@@ -183,20 +183,20 @@ class Strategy(object):
         )
         # --- from proj to affine
         inv = (P[1] * Q[1])
-        inv = (inv * PQ[1])
-        inv = (inv ** -1)
+        inv *= PQ[1]
+        inv **= -1
         # --- P
         PB_a = (Q[1] * PQ[1])
-        PB_a = (PB_a * inv)
-        PB_a = (PB_a * P[0])
+        PB_a *= inv
+        PB_a *= P[0]
         # --- Q
         QB_a = (P[1] * PQ[1])
-        QB_a = (QB_a * inv)
-        QB_a = (QB_a * Q[0])
+        QB_a *= inv
+        QB_a *= Q[0]
         # --- PQ
         PQB_a = (P[1] * Q[1])
-        PQB_a = (PQB_a * inv)
-        PQB_a = (PQB_a * PQ[0])
+        PQB_a *= inv
+        PQB_a *= PQ[0]
         return (PB_a, QB_a, PQB_a)
 
     def strategy_at_6_B(self, sk_b):
@@ -221,20 +221,20 @@ class Strategy(object):
         )
         # --- from proj to affine
         inv = (P[1] * Q[1])
-        inv = (inv * PQ[1])
-        inv = (inv ** -1)
+        inv *= PQ[1]
+        inv **= -1
         # --- P
         PA_b = (Q[1] * PQ[1])
-        PA_b = (PA_b * inv)
-        PA_b = (PA_b * P[0])
+        PA_b *= inv
+        PA_b *= P[0]
         # --- Q
         QA_b = (P[1] * PQ[1])
-        QA_b = (QA_b * inv)
-        QA_b = (QA_b * Q[0])
+        QA_b *= inv
+        QA_b *= Q[0]
         # --- PQ
         PQA_b = (P[1] * Q[1])
-        PQA_b = (PQA_b * inv)
-        PQA_b = (PQA_b * PQ[0])
+        PQA_b *= inv
+        PQA_b *= PQ[0]
         return (PA_b, QA_b, PQA_b)
 
     def strategy_A(self, sk_a, pk_b):
@@ -246,7 +246,7 @@ class Strategy(object):
         )
         #assert self.curve.issupersingular(A), "non-supersingular input curve"
         a24 = A[1] ** -1
-        a24 = a24 * A[0]
+        a24 *= A[0]
         RB_a = self.curve.Ladder3pt(
             sk_a,
             [PA_b, self.field(1)],
@@ -276,7 +276,7 @@ class Strategy(object):
         )
         #assert self.curve.issupersingular(A), "non-supersingular input curve"
         a24 = A[1] ** -1
-        a24 = a24 * A[0]
+        a24 *= A[0]
         RA_b = self.curve.Ladder3pt(
             sk_b,
             [PB_a, self.field(1)],

--- a/sibc/common.py
+++ b/sibc/common.py
@@ -1,18 +1,9 @@
 from functools import wraps
 from math import floor
 
+# Dictionary which provides attribute access to its keys.
 class attrdict(dict):
-    """
-    Dictionary which provides attribute access to its keys.
-    """
-
-    def __getattr__(self, key):
-        if key in self:
-            return self[key]
-        else:
-            raise AttributeError(
-                "%r object has no attribute %r" % (type(self).__name__, key)
-            )
+    __getattr__ = dict.__getitem__
 
 def strategy_evaluation(strategy, n):
 
@@ -79,10 +70,10 @@ def strategy_evaluation(strategy, n):
 def check(func):
     @wraps(func)
     def method(self, other):
-        if type(self) is not type(other):
+        if self.__class__ is not other.__class__:
             other = self.__class__(other)
         else:
-            if self.field.p != other.field.p:
+            if self.__class__.p != other.__class__.p:
                 raise ValueError
         return func(self, other)
 

--- a/sibc/csidh/gae_wd1.py
+++ b/sibc/csidh/gae_wd1.py
@@ -6,6 +6,11 @@ from sibc.math import isequal, bitlength, hamming_weight, cswap, sign
 from sibc.constants import parameters
 from sibc.common import geometric_serie, rounds
 
+class CachedIndexTuple(tuple):
+    def __init__(self, container):
+        self.cached_index = dict((b,a) for a,b in enumerate(container))
+        self.index = self.cached_index.__getitem__
+
 class Gae_wd1(object):
     def __init__(self, prime, tuned, curve, formula):
         self.random = SystemRandom()
@@ -17,10 +22,11 @@ class Gae_wd1(object):
         self.curve = curve
         self.prime = prime
         self.formula = formula
+        self.formula.L = CachedIndexTuple(self.formula.L)
         self.formula_name = formula.name
         self.field = self.curve.field
         self.tuned = tuned
-        self.L = parameters['csidh'][prime]['L']
+        self.L = CachedIndexTuple(parameters['csidh'][prime]['L'])
         self.m = parameters['csidh'][prime]['wd1']['m']
         self.c_xmul = self.curve.c_xmul
         n = parameters['csidh'][prime]['n']
@@ -130,6 +136,7 @@ class Gae_wd1(object):
             # (l_2, l_3, ..., l_{k+1)), ..., (l_{n-k}, l_{n-k+1, ..., l_{n)).
             for i in range(2, n + 1):
 
+                # TODOXXX see the loop unrolling in gae_df.py
                 for Tuple in get_neighboring_sets(L, i):
 
                     if self.C[i].get(Tuple) is None:

--- a/sibc/csidh/gae_wd2.py
+++ b/sibc/csidh/gae_wd2.py
@@ -6,6 +6,11 @@ from sibc.math import isequal, bitlength, hamming_weight, cswap, sign
 from sibc.constants import parameters
 from sibc.common import geometric_serie, rounds
 
+class CachedIndexTuple(tuple):
+    def __init__(self, container):
+        self.cached_index = dict((b,a) for a,b in enumerate(container))
+        self.index = self.cached_index.__getitem__
+
 class Gae_wd2(object):
     def __init__(self, prime, tuned, curve, formula):
         self.random = SystemRandom()
@@ -17,10 +22,11 @@ class Gae_wd2(object):
         self.curve = curve
         self.prime = prime
         self.formula = formula
+        self.formula.L = CachedIndexTuple(self.formula.L)
         self.formula_name = formula.name
         self.field = self.curve.field
         self.tuned = tuned
-        self.L = parameters['csidh'][prime]['L']
+        self.L = CachedIndexTuple(parameters['csidh'][prime]['L'])
         self.m = parameters['csidh'][prime]['wd2']['m']
         self.c_xmul = self.curve.c_xmul
         n = parameters['csidh'][prime]['n']

--- a/sibc/math.py
+++ b/sibc/math.py
@@ -1,8 +1,11 @@
 from random import SystemRandom
 #from progress.bar import Bar
 
-bitlength = lambda x: len(bin(x)[2:])  # number of bits
-hamming_weight = lambda x: bin(x).count("1")
+# number of bits, use builtin int.bit_length if present:
+bitlength = getattr(int, 'bit_length', lambda x: len(bin(x)[2:]))
+
+# python3.10 has builtin popcount aka hamming weight aka int.bit_count:
+hamming_weight = getattr(int, 'bit_count', lambda x: bin(x).count(r'1'))
 # hamming weight: number of bits equal 1
 
 sign = lambda x: (1, -1)[x < 0]  # Sign of an integer
@@ -122,7 +125,7 @@ def Brent_Cycle_finding_method(N : int):
                 y = ((y * y) % N + c) % N
                 q = q * (abs(x - y)) % N
             g = gcd(q, N)
-            k = k + m
+            k += m
         r *= 2
     if g == N:
         while True:

--- a/sibc/sidh/strategy.py
+++ b/sibc/sidh/strategy.py
@@ -108,20 +108,20 @@ class Strategy(object):
         )
         # --- from proj to affine
         inv = (P[1] * Q[1])
-        inv = (inv * PQ[1])
-        inv = (inv ** -1)
+        inv *= PQ[1]
+        inv **= -1
         # --- P
         PB_a = (Q[1] * PQ[1])
-        PB_a = (PB_a * inv)
-        PB_a = (PB_a * P[0])
+        PB_a *= inv
+        PB_a *= P[0]
         # --- Q
         QB_a = (P[1] * PQ[1])
-        QB_a = (QB_a * inv)
-        QB_a = (QB_a * Q[0])
+        QB_a *= inv
+        QB_a *= Q[0]
         # --- PQ
         PQB_a = (P[1] * Q[1])
-        PQB_a = (PQB_a * inv)
-        PQB_a = (PQB_a * PQ[0])
+        PQB_a *= inv
+        PQB_a *= PQ[0]
         return (PB_a, QB_a, PQB_a)
 
     def strategy_at_6_B(self, sk_b):
@@ -147,20 +147,20 @@ class Strategy(object):
         )
         # --- from proj to affine
         inv = (P[1] * Q[1])
-        inv = (inv * PQ[1])
-        inv = (inv ** -1)
+        inv *= PQ[1]
+        inv **= -1
         # --- P
         PA_b = (Q[1] * PQ[1])
-        PA_b = (PA_b * inv)
-        PA_b = (PA_b * P[0])
+        PA_b *= inv
+        PA_b *= P[0]
         # --- Q
         QA_b = (P[1] * PQ[1])
-        QA_b = (QA_b * inv)
-        QA_b = (QA_b * Q[0])
+        QA_b *= inv
+        QA_b *= Q[0]
         # --- PQ
         PQA_b = (P[1] * Q[1])
-        PQA_b = (PQA_b * inv)
-        PQA_b = (PQA_b * PQ[0])
+        PQA_b *= inv
+        PQA_b *= PQ[0]
         return (PA_b, QA_b, PQA_b)
 
     def strategy_A(self, sk_a, pk_b):
@@ -172,7 +172,7 @@ class Strategy(object):
         )
         #assert self.curve.issupersingular(A), "non-supersingular input curve"
         a24 = A[1] ** -1
-        a24 = a24 * A[0]
+        a24 *= A[0]
         RB_a = self.curve.Ladder3pt(
             sk_a,
             [PA_b, self.field(1)],
@@ -204,7 +204,7 @@ class Strategy(object):
         # Recall, 3-isogenies work with (A'+2C: A'-2C) = (A[0] : A[0] - A[1])
         #assert self.curve.issupersingular(A), "non-supersingular input curve"
         a24 = A[1] ** -1
-        a24 = a24 * A[0]
+        a24 *= A[0]
         RA_b = self.curve.Ladder3pt(
             sk_b,
             [PB_a, self.field(1)],


### PR DESCRIPTION
This is a pull request to request merging changes that improve the performance of CSIDH. The changes have been tested and measured for the sibc module's test suite. Measurement was completed before and after applying this change set on on x86_64 as well as on POWER9/ppc64le to show the performance improvements.

Performance of CSIDH is probably improved on every architecture supported by sibc but I have only run the entire test suite to completion successfully only on POWER9 and x86_64. I don't have a sufficiently fast RISC-V system to run the full test suite in a single day and my prediction is that it would take a long time. I also did not benchmark this on arm64 or armv7 or i386. It may be worth measuring performance on RISC-V and arm64 but I don't think it should block this merge request.

The comparisons below are not entirely equal as some of the versions of software such as Python itself, and the underlying libraries are different. The CPU architectures are also very different and this means that the cross CPU comparison is largely interesting to show deficiencies in what seems to be general Python performance.

As an example to show the performance increase note the performance of one p512 test at random to benchmark before applying the patch.

On x86_64:
```
time pytest -k csidh_gae_p512_hvelu_wd1__unscaled
========================================= test session starts =========================================
platform linux -- Python 3.9.2, pytest-7.1.2, pluggy-1.0.0 -- /home/resilient/Documents/sibc/sibc-venv/bin/python3
cachedir: .pytest_cache
rootdir: /home/resilient/Documents/sibc, configfile: pytest.ini
plugins: parallel-0.1.1
collected 309 items / 308 deselected / 1 selected                                                     

test/test_csidh.py::csidh_gae_p512_hvelu_wd1__unscaled::test_group_action_with_random_exponents PASSED [100%]

================================= 1 passed, 308 deselected in 25.42s ==================================

real	0m25.646s
user	0m27.217s
sys	0m5.799s
```

On POWER9/ppc64le:
```
time pytest-3 -k csidh_gae_p512_hvelu_wd1__unscaled
========================================= test session starts =========================================
platform linux -- Python 3.10.4, pytest-6.2.5, py-1.10.0, pluggy-0.13.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/user/src/sibc, configfile: pytest.ini
plugins: forked-1.4.0, xdist-2.5.0
collected 309 items / 308 deselected / 1 selected                                                     

test/test_csidh.py::csidh_gae_p512_hvelu_wd1__unscaled::test_group_action_with_random_exponents PASSED [100%]

============================ 1 passed, 308 deselected in 142.63s (0:02:22) ============================

real	2m23.509s
user	2m23.326s
sys	0m0.196s
```

After applying the patch, performance improved remarkably for this single test and additionally _all_ tests continue to pass.

On x86_64:
```
$ time pytest -k csidh_gae_p512_hvelu_wd1__unscaled
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.1.2, pluggy-1.0.0 -- /home/resilient/Documents/sibc/sibc-venv/bin/python3
cachedir: .pytest_cache
rootdir: /home/resilient/Documents/sibc, configfile: pytest.ini
plugins: parallel-0.1.1
collected 309 items / 308 deselected / 1 selected                              

test/test_csidh.py::csidh_gae_p512_hvelu_wd1__unscaled::test_group_action_with_random_exponents PASSED [100%]

====================== 1 passed, 308 deselected in 18.73s ======================

real    0m18.954s
user    0m20.448s
sys    0m5.881s
```

On POWER9/ppc64le:
```
time pytest-3 -k csidh_gae_p512_hvelu_wd1__unscaled
========================================== test session starts ==========================================
platform linux -- Python 3.10.4, pytest-6.2.5, py-1.10.0, pluggy-0.13.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/user/src/sibc, configfile: pytest.ini
plugins: forked-1.4.0, xdist-2.5.0
collected 309 items / 308 deselected / 1 selected                                                       

test/test_csidh.py::csidh_gae_p512_hvelu_wd1__unscaled::test_group_action_with_random_exponents PASSED [100%]

============================= 1 passed, 308 deselected in 87.69s (0:01:27) ==============================

real    1m28.410s
user    1m28.267s
sys     0m0.149s
```

The improvement for this single test on x86_64 is roughly seven seconds - not so impressive but certainly a big step in the right direction. On POWER9/ppc64le it is a reduction of nearly a full minute.

After applying the patch, the full test suite still takes a remarkably long time to run even when run on high end multi-core systems with many parallel tests. We probably want a way to run these tests quickly or people may be tempted to commit code without the full test suite running.

The full test suite POWER9/ppc64le _after_ the patch has been applied:
```
=================================== 309 passed in 28718.04s (7:58:38) ===================================
```

The full test suite on x86_64 _after_ the patch has been applied:
```
======================= 309 passed in 7259.67s (2:00:59) =======================
```


In summary, the relative CPU performance difference is a factor of roughly ~4.6 - ~4.7 for x86_64 vs ppc64le. Within each CPU architecture, the performance decrease in time from the previous revision of sibc is around ~26.3% for x86_64 and ~56.9% for POWER9/ppc64le, the absolute difference is ~30% for X86_64 and ~79.5% for POWER9/ppc64le.

I have not extensively profiled Python itself and I suspect that CPU vs CPU performance difference is in Python itself. This is part of the cost of nearly free portability by using pure Python. We may want to improve the performance with C, Golang, or Rust bindings at some point. It seems fruitful to consider improving Python itself such that everyone may realize generic improvements.

This patch greatly improves the performance of sibc in pure Python. I  request that it be merged if it passes a code review by @JJChiDguez. I am not the author of these improvements as the author prefers to remain nameless; I reviewed, and tested the patch extensively, and I am requesting a merge at the author's request.